### PR TITLE
Failed test issue

### DIFF
--- a/src/test/groovy/com/netflix/nebula/hollow/ApiGeneratorSpecification.groovy
+++ b/src/test/groovy/com/netflix/nebula/hollow/ApiGeneratorSpecification.groovy
@@ -22,14 +22,6 @@ class ApiGeneratorSpecification extends IntegrationSpec {
     def 'plugin applies'() {
         given:
         buildFile << """
-        buildscript {
-            repositories {
-                jcenter()
-            }
-            dependencies {
-                classpath "com.netflix.nebula:nebula-hollow-plugin:0.+"
-            }
-        }
         apply plugin: 'nebula.hollow'
         """
 
@@ -43,14 +35,6 @@ class ApiGeneratorSpecification extends IntegrationSpec {
     def 'generator task configures'() {
         given:
         buildFile << """
-        buildscript {
-            repositories {
-                jcenter()
-            }
-            dependencies {
-                classpath "com.netflix.nebula:nebula-hollow-plugin:0.+"
-            }
-        }
         apply plugin: 'nebula.hollow'
 
         hollow {
@@ -70,14 +54,6 @@ class ApiGeneratorSpecification extends IntegrationSpec {
     def 'execution of generator task is successful'() {
         given:
         buildFile << """
-            buildscript {
-                repositories {
-                    jcenter()
-                }
-                dependencies {
-                    classpath "com.netflix.nebula:nebula-hollow-plugin:0.+"
-                }
-            }
             apply plugin: 'java'
             apply plugin: 'nebula.hollow'
             

--- a/src/test/groovy/com/netflix/nebula/hollow/ApiGeneratorSpecification.groovy
+++ b/src/test/groovy/com/netflix/nebula/hollow/ApiGeneratorSpecification.groovy
@@ -139,7 +139,7 @@ class ApiGeneratorSpecification extends IntegrationSpec {
             'Entity2HollowFactory.java',
             'Entity2TypeAPI.java',
             'ListOfAtomicBooleanTypeAPI.java'
-        ].forEach { fileName ->
+        ].each { fileName ->
             assert getFile(fileName).exists()
         }
     }

--- a/src/test/groovy/com/netflix/nebula/hollow/ApiGeneratorSpecification.groovy
+++ b/src/test/groovy/com/netflix/nebula/hollow/ApiGeneratorSpecification.groovy
@@ -23,6 +23,14 @@ class ApiGeneratorSpecification extends IntegrationSpec {
     def 'plugin applies'() {
         given:
         buildFile << """
+        buildscript {
+            repositories {
+                jcenter()
+            }
+            dependencies {
+                classpath "com.netflix.nebula:nebula-hollow-plugin:0.2.1"
+            }
+        }
         apply plugin: 'nebula.hollow'
         """
 
@@ -36,6 +44,14 @@ class ApiGeneratorSpecification extends IntegrationSpec {
     def 'generator task configures'() {
         given:
         buildFile << """
+        buildscript {
+            repositories {
+                jcenter()
+            }
+            dependencies {
+                classpath "com.netflix.nebula:nebula-hollow-plugin:0.2.1"
+            }
+        }
         apply plugin: 'nebula.hollow'
 
         hollow {
@@ -52,10 +68,17 @@ class ApiGeneratorSpecification extends IntegrationSpec {
         noExceptionThrown()
     }
 
-    @Ignore
     def 'execution of generator task is successful'() {
         given:
         buildFile << """
+            buildscript {
+                repositories {
+                    jcenter()
+                }
+                dependencies {
+                    classpath "com.netflix.nebula:nebula-hollow-plugin:0.2.1"
+                }
+            }
             apply plugin: 'java'
             apply plugin: 'nebula.hollow'
             
@@ -65,6 +88,10 @@ class ApiGeneratorSpecification extends IntegrationSpec {
                 packagesToScan = ['org.package1', 'org.package2']
                 apiClassName = 'MyApiClassName'
                 apiPackageName = 'org.package3.api'
+            }
+            
+            repositories {
+                jcenter()
             }
                         
             dependencies {

--- a/src/test/groovy/com/netflix/nebula/hollow/ApiGeneratorSpecification.groovy
+++ b/src/test/groovy/com/netflix/nebula/hollow/ApiGeneratorSpecification.groovy
@@ -16,7 +16,6 @@
 package com.netflix.nebula.hollow
 
 import nebula.test.IntegrationSpec
-import spock.lang.Ignore
 
 class ApiGeneratorSpecification extends IntegrationSpec {
 
@@ -28,7 +27,7 @@ class ApiGeneratorSpecification extends IntegrationSpec {
                 jcenter()
             }
             dependencies {
-                classpath "com.netflix.nebula:nebula-hollow-plugin:0.2.1"
+                classpath "com.netflix.nebula:nebula-hollow-plugin:0.+"
             }
         }
         apply plugin: 'nebula.hollow'
@@ -49,7 +48,7 @@ class ApiGeneratorSpecification extends IntegrationSpec {
                 jcenter()
             }
             dependencies {
-                classpath "com.netflix.nebula:nebula-hollow-plugin:0.2.1"
+                classpath "com.netflix.nebula:nebula-hollow-plugin:0.+"
             }
         }
         apply plugin: 'nebula.hollow'
@@ -76,7 +75,7 @@ class ApiGeneratorSpecification extends IntegrationSpec {
                     jcenter()
                 }
                 dependencies {
-                    classpath "com.netflix.nebula:nebula-hollow-plugin:0.2.1"
+                    classpath "com.netflix.nebula:nebula-hollow-plugin:0.+"
                 }
             }
             apply plugin: 'java'


### PR DESCRIPTION
@toolbear 
Seems that it fixes the failed part of test

Also it looks like your environment works fine for 1st and 2nd tests, but it doesn't works in my env, during tests it produces:
```
com.netflix.nebula.hollow.ApiGeneratorSpecification > generator task configures FAILED
    org.spockframework.runtime.UnallowedExceptionThrownError at ApiGeneratorSpecification.groovy:59
        Caused by: org.gradle.api.GradleException at ApiGeneratorSpecification.groovy:56
            Caused by: org.gradle.internal.exceptions.LocationAwareException
                Caused by: org.gradle.api.GradleScriptException
                    Caused by: org.gradle.api.plugins.InvalidPluginException
                        Caused by: java.lang.ClassNotFoundException
```
That's why I've also added buildscript blocks for that tests, I hope it'll be useful for your env too

If nebula environment denies this blocks, then I guess the only extra block you need to fix the test is:
```
repositories {
    jcenter()
}
``` 
and replacing `forEach {}` with `each {}` as per 8f5b42a commit

I've just realized that it suffers from problem, that you can't really test **your current** version. You can only test the one, that was already uploaded to jcenter or install it locally before tests. Does netflixoss platform solves any problem like this on it's own? 
I saw a [ProjectSpec](https://github.com/nebula-plugins/nebula-test/blob/master/src/main/groovy/nebula/test/AbstractProjectSpec.groovy) class from nebula.test plugin, he allows to use `project.plugins.apply(PluginClass)` so it might be a solution, but then you are going to lose all the `IntegrationSpec` stuff