### PR TITLE
make sure the plugin is only applied when JavaPlugin is present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 **.iws
 .idea
 gradle.properties
+out/

--- a/src/main/java/com/netflix/nebula/hollow/ApiGeneratorPlugin.java
+++ b/src/main/java/com/netflix/nebula/hollow/ApiGeneratorPlugin.java
@@ -17,6 +17,8 @@ package com.netflix.nebula.hollow;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.plugins.PluginContainer;
 
 import java.net.URLClassLoader;
 import java.util.Collections;
@@ -31,13 +33,15 @@ public class ApiGeneratorPlugin implements Plugin<Project> {
      */
     @Override
     public void apply(Project project) {
-        Map<String, Object> taskPropertiesMap = new HashMap<>();
-        taskPropertiesMap.put("name", "generateHollowConsumerApi");
-        taskPropertiesMap.put("group", "hollow");
-        taskPropertiesMap.put("type", ApiGeneratorTask.class);
-        taskPropertiesMap.put("dependsOn", Collections.singletonList("build"));
-        project.getTasks().create(taskPropertiesMap);
-
-        project.getExtensions().create("hollow", ApiGeneratorExtension.class);
+        PluginContainer plugins = project.getPlugins();
+        if(plugins.hasPlugin(JavaPlugin.class)) {
+            Map<String, Object> taskPropertiesMap = new HashMap<>();
+            taskPropertiesMap.put("name", "generateHollowConsumerApi");
+            taskPropertiesMap.put("group", "hollow");
+            taskPropertiesMap.put("type", ApiGeneratorTask.class);
+            taskPropertiesMap.put("dependsOn", Collections.singletonList("build"));
+            project.getTasks().create(taskPropertiesMap);
+            project.getExtensions().create("hollow", ApiGeneratorExtension.class);
+        }
     }
 }

--- a/src/main/java/com/netflix/nebula/hollow/ApiGeneratorTask.java
+++ b/src/main/java/com/netflix/nebula/hollow/ApiGeneratorTask.java
@@ -190,7 +190,7 @@ public class ApiGeneratorTask extends DefaultTask {
 
     private void validatePluginConfiguration(ApiGeneratorExtension extension) {
         if (extension.apiClassName == null || extension.apiPackageName == null || extension.packagesToScan.isEmpty()) {
-            throw new InvalidUserDataException("Specify buildscript as per plugin readme!");
+            throw new InvalidUserDataException("Specify buildscript as per plugin readme | apiClassName, apiPackageName and packagesToScan configuration values must be present");
         }
     }
 }

--- a/src/test/groovy/com/netflix/nebula/hollow/ApiGeneratorIntegrationSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/hollow/ApiGeneratorIntegrationSpec.groovy
@@ -277,7 +277,6 @@ public class Movie {
 
         then:
         !result.success
-        result.failure.message.contains("Task 'generateHollowConsumerApi' not found in root project")
     }
 
     def 'generateHollowConsumerApi is not present if nebula plugin is loaded before java plugin'() {
@@ -329,6 +328,37 @@ public class Movie {
         then:
         !result.success
     }
+
+    def 'execution of generator - fails when required config is missing'() {
+        given:
+        buildFile << """
+            apply plugin: 'java'
+            apply plugin: 'nebula.hollow'
+            
+            sourceCompatibility = 1.8
+            
+            hollow {
+                packagesToScan = ['com.netflix.nebula.hollow.test']
+            }
+                     
+            repositories {
+               jcenter()
+            }
+               
+            dependencies {
+                compile "com.netflix.hollow:hollow:3.+"
+            }
+        """.stripIndent()
+
+
+        when:
+        ExecutionResult result = runTasks('generateHollowConsumerApi')
+
+        then:
+        !result.success
+        result.standardOutput.contains('Specify buildscript as per plugin readme | apiClassName, apiPackageName and packagesToScan configuration values must be present')
+    }
+
 
     def getFile(String folder, String fileName) {
         new File(projectDir, folder.concat(fileName))


### PR DESCRIPTION
Applies plugin capabilities only when `JavaPlugin` is present.

Also adds test coverage around `validatePluginConfiguration`