### PR TITLE
Add support for Kotlin data model classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ optional values:
 - `useHollowPrimitiveTypes` - specify to use Hollow Primitive Types instead of generating them per project. defaults to `true`
 - `restrictApiToFieldType` - api code only generates `get<FieldName>` with return type as per schema. defaults to `true`
 - `useVerboseToString` - will implement `toString()` method for hollow objects with `HollowRecordStringifier().stringify(this)`. defaults to `true`
+- `sourcesExtension` - the extension of your data classes. defaults to `".java"`
+- `filesToExclude` - files to exclude when scanning for data classes. defaults to `["package-info.java", "module-info.java"]`
+- `relativeCompileClassPaths` - the relative classpath of your compiled classes. defaults to `["/build/classes/main/", "/build/classes/java/main/"]`
+- `relativeDestinationPath` - the relative path to the api-related sources will be generated. defaults to `"/src/main/java/"`
+- `relativeSourcesPath` - the relative path to your data classes. defaults to `"/src/main/java/"`
 
 For more information, please refer to [`AbstractHollowAPIGeneratorBuilder`](https://github.com/Netflix/hollow/blob/master/hollow/src/main/java/com/netflix/hollow/api/codegen/AbstractHollowAPIGeneratorBuilder.java)
 launch task:

--- a/src/main/java/com/netflix/nebula/hollow/ApiGeneratorExtension.java
+++ b/src/main/java/com/netflix/nebula/hollow/ApiGeneratorExtension.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.nebula.hollow;
 
+import java.util.Arrays;
 import java.util.List;
 
 public class ApiGeneratorExtension {
@@ -24,7 +25,11 @@ public class ApiGeneratorExtension {
     public String apiPackageName;
     public String getterPrefix;
     public String classPostfix;
-    public String destinationPath;
+    public String sourcesExtension = ".java";
+    public List<String> filesToExclude = Arrays.asList("package-info.java", "module-info.java");
+    public List<String> relativeCompileClassPaths = Arrays.asList("/build/classes/main/", "/build/classes/java/main/");
+    public String relativeDestinationPath = "/src/main/java/";
+    public String relativeSourcesPath = "/src/main/java/";
     public boolean parameterizeAllClassNames = false;
     public boolean useAggressiveSubstitutions = false;
     public boolean useErgonomicShortcuts = true;

--- a/src/main/java/com/netflix/nebula/hollow/ApiGeneratorTask.java
+++ b/src/main/java/com/netflix/nebula/hollow/ApiGeneratorTask.java
@@ -56,8 +56,7 @@ public class ApiGeneratorTask extends DefaultTask {
             mapper.initializeTypeState(clazz);
         }
 
-        String apiTargetPath = extension.relativeDestinationPath != null && extension.relativeDestinationPath.isEmpty() ?
-            extension.relativeDestinationPath : buildPathToApiTargetFolder(absoluteDestinationPath, extension.apiPackageName);
+        String apiTargetPath = buildPathToApiTargetFolder(absoluteDestinationPath, extension.apiPackageName);
 
         HollowAPIGenerator generator = buildHollowAPIGenerator(extension, writeEngine, apiTargetPath);
         


### PR DESCRIPTION
The purpose of this PR is to add support for scanning of source files written in Kotlin.

The `HollowAPIGenerator` works fine with Kotlin model classes but this plugin can't pick them up due to hard-coded paths and extensions. 

I have thought of two approaches in adding the support:
1) Expose all paths/extensions as configurable properties with java defaults (allows good flexibility but more properties to set-up)
2) Expose a property that allows you to select the language and then map that to some pre-defined settings (lower flexibility but easier to set-up)

I use the 1st approach in this PR and in theory and if the `HollowAPIGenerator` supports other languages, it should work not only for Kotlin.

Additional changes:
- print a warning when no data classes were picked up

I am open to suggestions regarding the implementation. Please let me know what you think.

ping @rpalcolea @toolbear 